### PR TITLE
refactor: CIワークフローを責務別に分離

### DIFF
--- a/.github/workflows/code_analysis.yml
+++ b/.github/workflows/code_analysis.yml
@@ -1,0 +1,47 @@
+name: Code Analysis
+on: [pull_request]
+jobs:
+  biome:
+    name: Biome
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: mongolyy/reviewdog-action-biome@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+
+  typos:
+    name: Typos
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: reviewdog/action-typos@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-review
+
+  #test:
+  #  name: Test
+  #  runs-on: ubuntu-latest
+  #  steps:
+  #    - uses: actions/checkout@v4
+  #    - uses: oven-sh/setup-bun@v2
+  #    - run: bun install --frozen-lockfile
+  #    - run: bun test
+
+  #typecheck:
+  #  name: TypeCheck
+  #  runs-on: ubuntu-latest
+  #  steps:
+  #    - uses: actions/checkout@v4
+  #    - uses: oven-sh/setup-bun@v2
+  #    - run: bun install --frozen-lockfile
+  #    - run: bun run typecheck
+

--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -1,50 +1,6 @@
-name: PR
+name: Deploy Preview
 on: [pull_request]
 jobs:
-  biome:
-    name: Biome
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: mongolyy/reviewdog-action-biome@v1
-        with:
-          github_token: ${{ secrets.github_token }}
-          reporter: github-pr-review
-
-  typos:
-    name: Typos
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: reviewdog/action-typos@v1
-        with:
-          github_token: ${{ secrets.github_token }}
-          reporter: github-pr-review
-
-  #test:
-  #  name: Test
-  #  runs-on: ubuntu-latest
-  #  steps:
-  #    - uses: actions/checkout@v4
-  #    - uses: oven-sh/setup-bun@v2
-  #    - run: bun install --frozen-lockfile
-  #    - run: bun test
-
-  #typecheck:
-  #  name: TypeCheck
-  #  runs-on: ubuntu-latest
-  #  steps:
-  #    - uses: actions/checkout@v4
-  #    - uses: oven-sh/setup-bun@v2
-  #    - run: bun install --frozen-lockfile
-  #    - run: bun run typecheck
-
   deploy:
     name: Deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -1,4 +1,4 @@
-name: Push
+name: Deploy Production
 on:
   push:
     branches:


### PR DESCRIPTION
## Summary
- CIワークフローを責務ごとに分離し、保守性を向上
- コード分析、プレビューデプロイ、本番デプロイを独立したワークフローに整理
- ワークフロー名を用途に応じて明確化

## 変更内容
- `code_analysis.yml`: PR時のコード分析専用ワークフロー（Biome、Typos）
- `deploy_preview.yml`: PR時のプレビューデプロイ専用ワークフロー  
- `deploy_production.yml`: main push時の本番デプロイ専用ワークフロー

## Test plan
- [ ] PR作成時にコード分析ワークフローが実行される
- [ ] PR作成時にプレビューデプロイワークフローが実行される
- [ ] mainへのマージ後に本番デプロイワークフローが実行される

🤖 Generated with [Claude Code](https://claude.ai/code)