### PR TITLE
fix: カスタムドメインのルーティングパターンを修正

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -17,11 +17,11 @@
   },
   "routes": [
     {
-      "pattern": "grandcolline.com/*",
+      "pattern": "grandcolline.com",
       "custom_domain": true
     },
     {
-      "pattern": "www.grandcolline.com/*",
+      "pattern": "www.grandcolline.com",
       "custom_domain": true
     }
   ]


### PR DESCRIPTION
<!-- GitHub Copilot コードレビューへの指示: このプルリクをレビューしてコメントする際には日本語でお願いします。 -->

## 概要
- カスタムドメインのルーティングパターンから不要な `/*` を削除
- 正確なドメインマッチングを実現

## 変更内容
- `wrangler.jsonc` の routes 設定を修正
  - `grandcolline.com/*` → `grandcolline.com`
  - `www.grandcolline.com/*` → `www.grandcolline.com`

## テスト計画
- [x] ローカル環境でのビルド確認
- [x] Cloudflare Pages でのデプロイ確認
- [x] カスタムドメインでのアクセス確認

🤖 Generated with [Claude Code](https://claude.ai/code)